### PR TITLE
Repeat groups, issues #45, #56

### DIFF
--- a/automation/02b-syncToOpenFn.js
+++ b/automation/02b-syncToOpenFn.js
@@ -34,14 +34,23 @@ each(
           ? (mapKoboToPostgres.generated_uuid += '-' + (i + 1))
           : mapKoboToPostgres.generated_uuid;
 
+        let mapping = '';
+        if (columns[0].depth > 0) {
+          mapping = `state => state.data.${
+            columns[0].path[columns[0].depth - 1]
+          }.map(x => (${JSON.stringify(mapKoboToPostgres, null, 2).replace(
+            /"/g,
+            ''
+          )}))`;
+        }
         const operation = depth > 0 ? `upsertMany` : `upsert`;
 
         expression +=
-          `${operation}('${name}', 'generated_uuid', ${JSON.stringify(
-            mapKoboToPostgres,
-            null,
-            2
-          ).replace(/"/g, '')});` + '\n';
+          `${operation}('${name}', 'generated_uuid', ${
+            depth > 0
+              ? mapping
+              : JSON.stringify(mapKoboToPostgres, null, 2).replace(/"/g, '')
+          });` + '\n';
         state.data[i].expression = expression;
         state.data[i].triggerCriteria = { form: `${form_name}` };
       }


### PR DESCRIPTION
Things to look out for here:

1. Mapping logic for `upsertMany`
2. Uuid generation. Using `addUUIDs`, we are able to assign a Uuid to each element in `state.forms[].columns[]` but also each element in `state.forms[]`. Eventually the Uuid to use for the generation of the job is the latter. 

**Output Example for repeat groups**
```js
upsertMany(
  'copie_de_questionnaire_conso_ménage_29092020_derniere_version_info_consumption_history_protein_meal',
  'generated_uuid',
  state =>
    state.data.protein_meal.map(x => ({
      category1: dataValue('info_consumption_history/protein_meal/category1'),
      species: dataValue('info_consumption_history/protein_meal/species'),
      other_food: dataValue('info_consumption_history/protein_meal/other_food'),
      state: dataValue('info_consumption_history/protein_meal/state'),
      other_state: dataValue('info_consumption_history/protein_meal/other_state'),
      unit: dataValue('info_consumption_history/protein_meal/unit'),
      other_unit: dataValue('info_consumption_history/protein_meal/other_unit'),
      unit_number: dataValue('info_consumption_history/protein_meal/unit_number'),
      unit_price: dataValue('info_consumption_history/protein_meal/unit_price'),
      obtention: dataValue('info_consumption_history/protein_meal/obtention'),
      other_obtention: dataValue('info_consumption_history/protein_meal/other_obtention'),
      payload: state.data,
      generated_uuid: state.data._id - state.data._xform_id_string - 4,
    }))
);

```