### PR TITLE
for #68

### DIFF
--- a/automation/01-processForm.js
+++ b/automation/01-processForm.js
@@ -2,8 +2,8 @@ get(`${state.data.url}`, {}, state => {
   const { survey } = state.data.content;
 
   // PREFIX HANDLER
-  const prefix1 = 'WCS';
-  const prefix2 = 'FormGroup';
+  const prefix1 = state.data.prefix1 || 'WCS';
+  const prefix2 = state.data.prefix2 || 'FormGroup';
   // END OF PREFIX HANDLER
 
   // TODO: Decide which metadata field to include. ========================


### PR DESCRIPTION
@aleksa-krolls and @ritazagoni , I think this may be sufficient for #68 . The user clicks the " + " on Inbox and types the following. It will trigger the execution of job `01-processForm.js` which fetches just that single form and processes it. The only change, is that now they can specify a `prefix1` and `prefix2` each time they choose to process a form.
```json
{
  "formId": "aZv8deXKd8AqfSVGXCdHrX",
  "tag": "Copie_de_Questionnaire_conso-ménage_29092020 derniere version",
  "url": "https://kf.kobotoolbox.org/api/v2/assets/aZv8deXKd8AqfSVGXCdHrX/?format=json",
  "formUpdate": true,
  "prefix1": "custom",
  "prefix2": "custom"
}
```
![image](https://user-images.githubusercontent.com/8732845/98524695-71269400-226f-11eb-84ce-4cc3a0c1a4ef.png)
